### PR TITLE
Copy build and deploy from epiforecasts quarto site

### DIFF
--- a/.github/workflows/render_blueprints.yml
+++ b/.github/workflows/render_blueprints.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          path: ./_site
+          path: ./_book
 
   # Deployment job
   deploy:

--- a/.github/workflows/render_blueprints.yml
+++ b/.github/workflows/render_blueprints.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: r-lib/actions/setup-tinytex@v2
+
       - uses: quarto-dev/quarto-actions/setup@main
 
       - name: Render site

--- a/.github/workflows/render_blueprints.yml
+++ b/.github/workflows/render_blueprints.yml
@@ -1,27 +1,47 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
+  workflow_dispatch:
   push:
-    branches: main
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
 
-name: Render and Publish
+name: Render blueprints
 
 jobs:
-  build-deploy:
+  build:
     runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      LANG: "en_US.UTF-8"
+      LC_ALL: "en_US.UTF-8"
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v2
 
-      - name: Set up Quarto
-        uses: quarto-dev/quarto-actions/setup@v2
-        with:
-          # To install LaTeX to build PDF book
-          tinytex: true
-          # uncomment below and fill to pin a version
-          # version: 0.9.600
+      - uses: quarto-dev/quarto-actions/setup@main
 
-      - name: Publish to GitHub Pages (and render)
-        uses: quarto-dev/quarto-actions/publish@v2
+      - name: Render site
+        run: quarto render
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
         with:
-          target: gh-pages
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # this secret is always available for github actions
+          path: ./_site
+
+  # Deployment job
+  deploy:
+    if: github.event_name != 'pull_request'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
This is a two-steps workflow:

- build the website (runs on push & PR for testing purpose)
- deploy the website (only runs on push)

Tested here: https://github.com/epiforecasts/epiforecasts.github.io/blob/543c9ed8470859a20a61642035a6f9f0373167b0/.github/workflows/build-and-deploy.yaml