### PR TITLE
Make sure dependencies page is rendered

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -8,6 +8,7 @@ book:
   chapters:
     - index.qmd
     - principles.qmd
+    - dependencies.qmd
     - git-branching-merging.qmd
     - code-review.qmd
     - contribution-acknowledgements.qmd

--- a/principles.qmd
+++ b/principles.qmd
@@ -131,6 +131,7 @@ As an open-source initiative, Epiverse-TRACE will benefit from numerous other OS
 
 ::: {.callout-tip title="Read more about this principle in application"}
 
+- [Epiverse-TRACE Package Dependency Guidelines](./dependencies.qmd)
 - [From disconnected elements to a harmonious ecosystem: the Epiverse-TRACE project](https://epiverse-trace.github.io/slides/harmonious-ecosystem/)
 - [Converting your R Function to an S3 Generic: benefits, pitfalls & design considerations](https://epiverse-trace.github.io/posts/s3-generic/)
 - [Extending Data Frames: Creating custom classes and {dplyr} compatibility](https://epiverse-trace.github.io/posts/extend-dataframes/)

--- a/principles.qmd
+++ b/principles.qmd
@@ -131,7 +131,6 @@ As an open-source initiative, Epiverse-TRACE will benefit from numerous other OS
 
 ::: {.callout-tip title="Read more about this principle in application"}
 
-- [Epiverse-TRACE Package Dependency Guidelines](dependencies)
 - [From disconnected elements to a harmonious ecosystem: the Epiverse-TRACE project](https://epiverse-trace.github.io/slides/harmonious-ecosystem/)
 - [Converting your R Function to an S3 Generic: benefits, pitfalls & design considerations](https://epiverse-trace.github.io/posts/s3-generic/)
 - [Extending Data Frames: Creating custom classes and {dplyr} compatibility](https://epiverse-trace.github.io/posts/extend-dataframes/)


### PR DESCRIPTION
This PR removes a broken URL I observed while reading the blueprints. I could not find the correct destination within the blueprints pages itself, so I removed it to open this PR.

This is a suggestion - I may very well miss the actual link it should go to.