### PR TITLE
Add automated release guideline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 _book
 
 /.quarto/
+.DS_Store

--- a/principles.qmd
+++ b/principles.qmd
@@ -113,6 +113,7 @@ Consistent, high quality, and accessible documentation is key to adopting softwa
 - Write documentation assuming minimum R literacy and prior knowledge
 - Content should clearly state requirements, objectives, and value for the user
 - Aim to provide translations for the most common languages
+- We aim to provide [automated blog posts for major and minor releases](https://epiverse-trace.github.io/blog.html#category=new-release). Code owners may occasionally decide to release patch blogs if the patch is critical.
 
 ## Being part of the OSS landscape
 


### PR DESCRIPTION
This PR adds a blueprint guideline regarding automated blog posts for new releases of packages. This change follows on the discussions in https://github.com/epiverse-trace/epiverse-trace.github.io/issues/135, where it became clear that a guideline can provide clarity. Inviting the original participants of the discussion for sharing their thoughts :-)

This PR explicates that patch release blogs are not a necessity, but are possible at the discretion of the code owner. This helps unburden those who may feel like it is a necessity, but also gives flexibility for the code owners of the package to make the final call (context matters).

## Scenario 

I can imagine the scenario where a patch is for a critical vulnerability may require an urgent update to our community in the form of a blog. It also gives guidance to team members that they are not required to release a blog for patches.

## Next steps

Given this is a small change that will not substantively change the immediate situation, I will move ahead if no objections arise before end of the week.
