### PR TITLE
Add base R support schedule

### DIFF
--- a/dependencies.qmd
+++ b/dependencies.qmd
@@ -34,6 +34,21 @@ We carefully evaluate the potential benefits of data.table as a dependency based
 
 We embrace an [iterative development approach](principles.html#lean-and-agile-collaboration-framework) where dependencies can evolve over time. Initially, dependencies can be included to quickly build a Minimum Viable Product (MVP) and gain early feedback. However, we recognize that not all dependencies may bring significant value in the long-run. Therefore, we encourage package maintainers to regularly evaluate the usefulness and impact of dependencies and remove those that do not contribute substantially to the package. The [itdepends package](https://github.com/r-lib/itdepends) can help to identify dependencies that are used just one time in a given package or codebase. Such dependencies are good candidates for removal.
 
+### Base R support schedule
+
+We maintain a minimum support for the last four versions of R ([the {tidyverse} standard](https://www.tidyverse.org/blog/2019/04/r-version-support/)). The table outlines the concrete minimum supported version.
+
+| Year | Current R version | Minimum supported version |
+|------|-------------------|---------------------------|
+| 2019 | 3.6               | 3.2                       |
+| 2020 | 4.0               | 3.3                       |
+| 2021 | 4.1               | 3.4                       |
+| 2022 | 4.2               | 3.5                       |
+| 2023 | 4.3               | 3.6                       |
+| 2024 | 4.4               | 4.0                       |
+| 2025 | 4.5               | 4.1                       |
+| 2026 | 4.6               | 4.2                       |
+
 ## Additional Recommendations
 
 We trust the individual developer choices while ensuring that they can justify the dependencies they include. When in doubt, we encourage developers to raise an issue to initiate discussions with the community and explore alternative options. While it may not be necessary for all cases, we recommend including discussions on dependencies in design vignettes or documentation to provide clarity, and inform future maintainers of the reasons behind our choices. Additionally, [we encourage the use of hard, objective metrics to guide dependency choices](https://www.tidyverse.org/blog/2019/05/itdepends/), striking a balance between flexibility and standardization.


### PR DESCRIPTION
This PR adds the support schedule for R versions, as discussed on Slack. I added it in this specific section as it made most sense here in the overall (current) structure.

This provides clarity, making previously implicit standards explicit. :blush:
