### PR TITLE
enable lightbox for principles chapter

### DIFF
--- a/principles.qmd
+++ b/principles.qmd
@@ -1,5 +1,6 @@
 ---
 title: General principles
+lightbox: true
 ---
 
 The recommendations below aim to cover the most important aspects of the development of *Epiverse-TRACE*. For simplicity, we distinguish *users* from *developers* according to the type of contributions they make to a software project: *developers* create content (code and documentation), while *users* advise, test, and provide feedback on content [^1]. User-bases will be project-dependent but would typically include field epidemiologists or public health officers.


### PR DESCRIPTION
Fix #105

Maybe this could be done for the whole book at once instead.

I've noticed there's no alternative text for the pictures (only the caption that lacks information).