### PR TITLE
Add paragraph mentioning and linking to packagetemplate

### DIFF
--- a/principles.qmd
+++ b/principles.qmd
@@ -23,6 +23,8 @@ The mindmap below provides an overview of the blueprints content. Please refer t
 
 This page is focused on general principles of the project and for each one of these principles, we link to other sections of the book detailing the practical application of these principles in our processes.
 
+Additionally, these principles are implemented in a GitHub template repository: [epiverse-trace/packagetemplate](https://github.com/epiverse-trace/packagetemplate). This template repository is aiming to facilitate the adoption of the standards presented here and provide a quick start point for new packages. Further information about this template repository is available in the [dedicated wiki](https://github.com/epiverse-trace/packagetemplate/wiki).
+
 ## Software development as co-creation
 
 Useful software development is unlikely to be achieved by developers alone: rather, it needs to be co-created by users and developers. Some key principles of this co-creation include:

--- a/principles.qmd
+++ b/principles.qmd
@@ -23,7 +23,7 @@ The mindmap below provides an overview of the blueprints content. Please refer t
 
 This page is focused on general principles of the project and for each one of these principles, we link to other sections of the book detailing the practical application of these principles in our processes.
 
-Additionally, these principles are implemented in a GitHub template repository: [epiverse-trace/packagetemplate](https://github.com/epiverse-trace/packagetemplate). This template repository is aiming to facilitate the adoption of the standards presented here and provide a quick start point for new packages. Further information about this template repository is available in the [dedicated wiki](https://github.com/epiverse-trace/packagetemplate/wiki).
+Additionally, these principles are implemented in a [GitHub template repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template): [epiverse-trace/packagetemplate](https://github.com/epiverse-trace/packagetemplate). This template repository is aiming to facilitate the adoption of the standards presented here and provide a quick start point for new packages. Further information about this template repository is available in the [dedicated wiki](https://github.com/epiverse-trace/packagetemplate/wiki).
 
 ## Software development as co-creation
 


### PR DESCRIPTION
Fix #45.

This PR explains the relationship between the blueprint and packagetemplate. The blueprints are the theoretical guiding principles, while packagetemplate is the practical implementation of the principles described here.